### PR TITLE
Added email link to social sharing

### DIFF
--- a/source/javascripts/vendor/share.js
+++ b/source/javascripts/vendor/share.js
@@ -9,20 +9,39 @@
                 config.selector + " label{font-size:16px;cursor:pointer;padding: 8px 10px;border-radius:3px;background:" + config.button_background + ";color:" + config.button_color + ";-webkit-transition:all .3s ease;transition:all .3s ease}" +
                 config.selector + " label:hover{color:#555;}" +
                 config.selector + " label span{padding-left:6px;text-transform:none;font-weight:500;}" +
-                config.selector + " .social{-webkit-transform-origin:50% 0;-ms-transform-origin:50% 0;transform-origin:50% 0;-webkit-transform:scale(0) translateY(-190px);-ms-transform:scale(0) translateY(-190px);transform:scale(0) translateY(-190px);opacity:0;-webkit-transition:all .4s ease;transition:all .4s ease;margin-left:-15px}" +
-                config.selector + " .social.active{opacity:1;-webkit-transform:scale(1) translateY(-90px);-ms-transform:scale(1) translateY(-90px);transform:scale(1) translateY(-90px);-webkit-transition:all .4s ease;transition:all .4s ease;margin-left:-45px}" +
-                config.selector + " ul{position:relative;left:0;right:0;width:180px;height:46px;color:#fff;background:#3b5998;margin:auto;padding:0;list-style:none}" +
-                config.selector + " ul li{font-size:20px;cursor:pointer;width:60px;margin:0;padding:12px 0;text-align:center;float:left;display:block;height:22px;position:relative;z-index:2;-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;-webkit-transition:all .3s ease;transition:all .3s ease}" +
-                config.selector + " ul:after{content:'';display:block;width:0;height:0;position:absolute;left:0;right:0;margin:35px auto;border-left:20px solid transparent;border-right:20px solid transparent;border-top:20px solid #3b5998}" +
-                config.selector + " li[class*=twitter]{background:#6cdfea;padding:12px 0}" +
-                config.selector + " li[class*=gplus]{background:#e34429;padding:12px 0}" +
+                config.selector + " .social{-webkit-transform-origin:50% 0;-ms-transform-origin:50% 0;transform-origin:50% 0;-webkit-transform:scale(0) translateY(-190px);-ms-transform:scale(0) translateY(-190px);transform:scale(0) translateY(-190px);opacity:0;-webkit-transition:all .4s ease;transition:all .4s ease;margin-left:-30px}" +
+                config.selector + " .social.active{opacity:1;-webkit-transform:scale(1) translateY(-90px);-ms-transform:scale(1) translateY(-90px);transform:scale(1) translateY(-90px);-webkit-transition:all .4s ease;transition:all .4s ease;margin-left:-75px}" +
+                config.selector + " ul{position:relative;left:0;right:0;width:240px;height:46px;color:#fff;background:#555;margin:auto;padding:0;list-style:none}" +
+                config.selector + " ul:before,ul:after{content:'';display:block;width:0;height:0;position:absolute;top:45px;left:50%;right:0;border:5px solid transparent;}" +
+                config.selector + " ul:before{border-top-color:#e34429;border-left-color:#e34429;}" +
+                config.selector + " ul:after{border-top-color:#3b5998;border-right-color:#3b5998;margin-left:-10px;}" +
+                config.selector + " ul li{font-size:20px;cursor:pointer;width:60px;margin:0;padding:10px 0 14px;text-align:center;float:left;display:block;height:22px;position:relative;z-index:2;-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;-webkit-transition:all .3s ease;transition:all .3s ease}" +
+                config.selector + " ul li a{color: #fff;}" +
+                config.selector + " li[class*=facebook]{background:#3b5998;}" +
+                config.selector + " li[class*=twitter]{background:#6cdfea;}" +
+                config.selector + " li[class*=gplus]{background:#e34429;}" +
             "</style>"
     };
     $.fn.share = function (t) {
         var e, o, i, n, a, r, l, s, c = this;
         return $(this).hide(), null == t && (t = {}), n = {}, n.url = t.url || window.location.href, n.text = t.text || $("meta[name=description]").attr("content") || "", n.app_id = t.app_id, n.title = t.title, n.image = t.image, n.button_color = t.color || "#333", n.button_background = t.background || "#e1e1e1", n.button_icon = t.icon || "export", n.button_text = t.button_text || "Share", l = function (e, o) {
             return t[e] ? t[e][o] || n[o] : n[o]
-        }, n.twitter_url = l("twitter", "url"), n.twitter_text = l("twitter", "text"), n.fb_url = l("facebook", "url"), n.fb_title = l("facebook", "title"), n.fb_caption = l("facebook", "caption"), n.fb_text = l("facebook", "text"), n.fb_image = l("facebook", "image"), n.gplus_url = l("gplus", "url"), n.selector = "." + $(this).attr("class"), n.twitter_text = encodeURIComponent(n.twitter_text), "integer" == typeof n.app_id && (n.app_id = n.app_id.toString()), $("meta[name=sharer]").length || $("head").append(getStyles(n)), $(this).html("<label class='entypo-" + n.button_icon + "'><span>" + n.button_text + "</span></label><div class='social'><ul><li class='entypo-twitter' data-network='twitter'></li><li class='entypo-facebook' data-network='facebook'></li><li class='entypo-gplus' data-network='gplus'></li></ul></div>"), !window.FB && n.app_id && $("body").append("<div id='fb-root'></div><script>(function(a,b,c){var d,e=a.getElementsByTagName(b)[0];a.getElementById(c)||(d=a.createElement(b),d.id=c,d.src='//connect.facebook.net/en_US/all.js#xfbml=1&appId=" + n.app_id + "',e.parentNode.insertBefore(d,e))})(document,'script','facebook-jssdk');</script>"), r = {
+        },
+        n.twitter_url = l("twitter", "url"),
+        n.twitter_text = l("twitter", "text"),
+        n.fb_url = l("facebook", "url"),
+        n.fb_title = l("facebook", "title"),
+        n.fb_caption = l("facebook", "caption"),
+        n.fb_text = l("facebook", "text"),
+        n.fb_image = l("facebook", "image"),
+        n.gplus_url = l("gplus", "url"),
+        n.selector = "." + $(this).attr("class"),
+        n.twitter_text = encodeURIComponent(n.twitter_text),
+        "integer" == typeof n.app_id && (n.app_id = n.app_id.toString()),
+        $("meta[name=sharer]").length || $("head").append(getStyles(n)),
+        $(this).html("<label class='entypo-" + n.button_icon + "'><span>" + n.button_text + "</span></label><div class='social'><ul><li class='entypo-twitter' data-network='twitter'></li><li class='entypo-facebook' data-network='facebook'></li><li class='entypo-gplus' data-network='gplus'></li><li><a class='entypo-mail' href='mailto:?subject=" + t.subject + "&body=" + t.body + "'></a></li></ul></div>"),
+        !window.FB && n.app_id && $("body").append("<div id='fb-root'></div><script>(function(a,b,c){var d,e=a.getElementsByTagName(b)[0];a.getElementById(c)||(d=a.createElement(b),d.id=c,d.src='//connect.facebook.net/en_US/all.js#xfbml=1&appId=" + n.app_id + "',e.parentNode.insertBefore(d,e))})(document,'script','facebook-jssdk');</script>"),
+        r = {
             twitter: "http://twitter.com/intent/tweet?text=" + n.twitter_text + "&url=" + n.twitter_url,
             facebook: "https://www.facebook.com/sharer/sharer.php?u=" + n.fb_url,
             gplus: "https://plus.google.com/share?url=" + n.gplus_url
@@ -34,14 +53,17 @@
             return e.removeClass("active")
         }, o = function () {
             var t;
-            return t = r[$(this).data("network")], "facebook" === $(this).data("network") && n.app_id ? window.FB.ui({
-                method: "feed",
-                name: n.fb_title,
-                link: n.fb_url,
-                picture: n.fb_image,
-                caption: n.fb_caption,
-                description: n.fb_text
-            }) : window.open(t, "targetWindow", "toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=500,height=350"), !1
+
+            if($(this).data("network")) {
+              return t = r[$(this).data("network")], "facebook" === $(this).data("network") && n.app_id ? window.FB.ui({
+                  method: "feed",
+                  name: n.fb_title,
+                  link: n.fb_url,
+                  picture: n.fb_image,
+                  caption: n.fb_caption,
+                  description: n.fb_text
+              }) : window.open(t, "targetWindow", "toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=500,height=350"), !1
+            }
         }, $(this).find("label").on("click", s), $(this).find("li").on("click", o), $("body").on("click", function () {
             return e.hasClass("active") ? e.removeClass("active") : void 0
         }), setTimeout(function () {

--- a/source/layouts/post.html.haml
+++ b/source/layouts/post.html.haml
@@ -21,8 +21,10 @@
       :coffeescript
         $ ->
           $(".share").share
-            url: "#{current_page.url}"
-            text: "#{current_page.data.title} (#{current_page.url})"
+            url: document.URL
+            text: "#{current_page.data.title} (" + document.URL + ")"
+            subject: "#{current_page.data.title}"
+            body: "#{current_page.data.title}%0D%0A#{current_page.data.body}%0D%0A%0D%0AView the post by Andrew Eick:%0D%0A" + document.URL
             color: "#999"
             background: "#efefef"
 


### PR DESCRIPTION
The social sharing button now has an 'Email' option. I had to split the colors on the pointer arrow but I think it still looks nice (screenshot below).

For now I am using the post title as the subject, and then using the body of the post as the body of the email followed by a link and attribution. I can change it if there's a different message you'd like to use.

Share popup:
![screen shot 2014-02-09 at 10 45 28 am](https://f.cloud.github.com/assets/111194/2120271/aa71c094-91a9-11e3-87ac-6f6cffbce119.png)

Email it produces:
![screen shot 2014-02-09 at 11 52 44 am](https://f.cloud.github.com/assets/111194/2120420/19d16bf2-91b3-11e3-8ab6-c73ced635c27.png)

To check it out you can just use 'git checkout social-sharing', which should pull down what I have and switch you to that branch. Then after merging on Github you can switch back to master 'git checkout master' and then 'git branch -D social-sharing' to delete that branch locally.
